### PR TITLE
Deserialize subproblem creation, add timing to Problem methods

### DIFF
--- a/dede/problem.py
+++ b/dede/problem.py
@@ -29,6 +29,14 @@ from .utils import (
 ObjectiveT = t.Union[cp.Maximize, cp.Minimize]
 ConstraintT = t.Union[Equality, Zero, Inequality]
 
+# These define parameters needed to be passed to the solvers to make them only use one thread.
+THREAD_OPTS: dict[str, dict[str, int]] = {
+    cp.GUROBI: {"Threads": 1},
+    # ECOS/ECOS_BB do not have settings for threading
+    cp.ECOS: {},
+    cp.ECOS_BB: {},
+}
+
 
 def timer(func):
     @functools.wraps(func)
@@ -317,6 +325,8 @@ class Problem(CpProblem):
 
             coeff = 1 if self._problem_type == Minimize else -1
             return t.cast(np.floating[t.Any], coeff * self.value)
+
+        kwargs.update(THREAD_OPTS.get(kwargs.get("solver", ""), {}))
 
         subproblems_invalidated = self._subprob_cache.update_cache(rho, num_cpus, ray_address)
         if subproblems_invalidated:

--- a/dede/problem.py
+++ b/dede/problem.py
@@ -437,24 +437,26 @@ class Problem(CpProblem):
                 var.value[idx] = value
 
     @classmethod
-    def _get_constr_dict(cls, constrs: list[cp.Constraint]) -> dict[cp.Constraint, list[VarInfoT]]:
+    def _get_constr_dict(cls, constrs: list[cp.Constraint]) -> dict[int, list[VarInfoT]]:
         """Get a mapping of constraint to its var_id_pos_list."""
-        constr_to_var_id_pos_list: dict[cp.Constraint, list[VarInfoT]] = {}
+        constr_to_var_id_pos_list: dict[int, list[VarInfoT]] = {}
         for constr in constrs:
             # [constr] = get_var_id_pos_list_from_linear(constr.expr, self._solver)
-            constr_to_var_id_pos_list[constr] = get_var_id_pos_list_from_linear(constr.expr)
+            constr_to_var_id_pos_list[t.cast(int, constr.id)] = get_var_id_pos_list_from_linear(
+                constr.expr
+            )
         return constr_to_var_id_pos_list
 
     @classmethod
     def _group_constrs(
-        cls, constrs: list[cp.Constraint], constr_dict: dict[cp.Constraint, list[VarInfoT]]
+        cls, constrs: list[cp.Constraint], constr_dict: dict[int, list[VarInfoT]]
     ) -> list[list[cp.Constraint]]:
         """Group constraints into non-overlapped groups with union-find."""
         uf = UnionFind(len(constrs))
 
         var_id_pos_to_i: dict[VarInfoT, int] = {}
         for i, constr in enumerate(constrs):
-            for var_id_pos in constr_dict[constr]:
+            for var_id_pos in constr_dict[constr.id]:
                 if var_id_pos in var_id_pos_to_i:
                     uf.union(var_id_pos_to_i[var_id_pos], i)
                 var_id_pos_to_i[var_id_pos] = i
@@ -493,8 +495,8 @@ class Problem(CpProblem):
         obj_expr_d_ref = ray.put(obj_expr_d)
         constrs_r_ref = ray.put(self.constrs_gps_r)
         constrs_d_ref = ray.put(self.constrs_gps_d)
-        constr_dict_r_ref = ray.put({key.id: value for key, value in self.constr_dict_r.items()})
-        constr_dict_d_ref = ray.put({key.id: value for key, value in self.constr_dict_d.items()})
+        constr_dict_r_ref = ray.put(self.constr_dict_r)
+        constr_dict_d_ref = ray.put(self.constr_dict_d)
         var_id_pos_set_r_ref = ray.put(var_id_pos_set_r)
         var_id_pos_set_d_ref = ray.put(var_id_pos_set_d)
 
@@ -583,7 +585,7 @@ class Problem(CpProblem):
             ):
                 for j, constrs in enumerate(constrs_gps):
                     for constr in constrs:
-                        for var_id_pos in constr_dict[constr]:
+                        for var_id_pos in constr_dict[constr.id]:
                             var_id_pos_to_idx[var_id_pos].append((i, j))
 
             expr_list = expand_expr(self.objective.expr)

--- a/dede/problem.py
+++ b/dede/problem.py
@@ -232,8 +232,6 @@ class Problem(CpProblem):
             resource_variables: list of resource constraints
             demand_variables: list of demand constraints
         """
-        start = time.time()
-
         # breakdown constraints
         constrs_r_converted = [self._convert_inequality(constr) for constr in resource_constraints]
         constrs_d_converted = [self._convert_inequality(constr) for constr in demand_constraints]
@@ -280,9 +278,6 @@ class Problem(CpProblem):
 
         self._obj_expr_r = None
         self._obj_expr_d = None
-
-        end = time.time()
-        print("init time:", end - start)
 
     @classmethod
     def _convert_inequality(cls, constr: ConstraintT) -> cp.Constraint:

--- a/dede/problem.py
+++ b/dede/problem.py
@@ -535,9 +535,9 @@ class Problem(CpProblem):
     ) -> tuple[list[list[int]], list[list[int]]]:
         """Get parameter z index in last solution."""
         # map var_id_pos in the big resource solution list
-        sol_idx_r: list[list[VarInfoT]] = ray.get(
-            [prob.get_solution_idx_r.remote() for prob in probs]
-        )
+        sol_idx_r_futures = [prob.get_solution_idx_r.remote() for prob in probs]
+        sol_idx_l_futures = [prob.get_solution_idx_d.remote() for prob in probs]
+        sol_idx_r: list[list[VarInfoT]] = ray.get(sol_idx_r_futures)
 
         sol_idx_dict_r: dict[VarInfoT, int] = {}
         idx = 0
@@ -547,9 +547,7 @@ class Problem(CpProblem):
                 idx += 1
 
         # map var_id_pos in the big demand solution list
-        sol_idx_d: list[list[VarInfoT]] = ray.get(
-            [prob.get_solution_idx_d.remote() for prob in probs]
-        )
+        sol_idx_d: list[list[VarInfoT]] = ray.get(sol_idx_l_futures)
         sol_idx_dict_d: dict[VarInfoT, int] = {}
         idx = 0
         for sol_idx in sol_idx_d:

--- a/dede/problem.py
+++ b/dede/problem.py
@@ -502,8 +502,8 @@ class Problem(CpProblem):
         probs: list[ray.actor.ActorProxy[SubproblemsWrap]] = []
         for cpu in range(num_cpus):
             # get constraint idx for the group
-            idx_r: list[int] = constrs_gps_idx_r[cpu::num_cpus].tolist()
-            idx_d: list[int] = constrs_gps_idx_d[cpu::num_cpus].tolist()
+            idx_r: NDArray[np.signedinteger] = constrs_gps_idx_r[cpu::num_cpus]
+            idx_d: NDArray[np.signedinteger] = constrs_gps_idx_d[cpu::num_cpus]
 
             # build subproblems
             actor = ray.remote(SubproblemsWrap).options(

--- a/dede/problem.py
+++ b/dede/problem.py
@@ -1,4 +1,5 @@
 import contextlib
+import functools
 import time
 import typing as t
 from collections import defaultdict
@@ -27,6 +28,25 @@ from .utils import (
 
 ObjectiveT = t.Union[cp.Maximize, cp.Minimize]
 ConstraintT = t.Union[Equality, Zero, Inequality]
+
+
+def timer(func):
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        start_time = time.perf_counter()
+        result = func(*args, **kwargs)
+        end_time = time.perf_counter()
+        print(f"Executed {func.__name__} in {end_time - start_time:.4f}s")
+        return result
+
+    return wrapper
+
+
+def time_all_methods(cls):
+    for name, val in vars(cls).items():
+        if callable(val):
+            setattr(cls, name, timer(val))
+    return cls
 
 
 @contextlib.contextmanager
@@ -196,6 +216,7 @@ class RaySubprobCache:
         return self._placement_group
 
 
+@time_all_methods
 class Problem(CpProblem):
     """Build a resource allocation problem."""
 
@@ -462,25 +483,23 @@ class Problem(CpProblem):
         for var_id_pos in self.constr_dict_d.values():
             var_id_pos_set_d.update(var_id_pos)
 
+        # serialize expensive objects exactly once
+        obj_expr_r_ref = ray.put(obj_expr_r)
+        obj_expr_d_ref = ray.put(obj_expr_d)
+        constrs_r_ref = ray.put(self.constrs_gps_r)
+        constrs_d_ref = ray.put(self.constrs_gps_d)
+        constr_dict_r_ref = ray.put({key.id: value for key, value in self.constr_dict_r.items()})
+        constr_dict_d_ref = ray.put({key.id: value for key, value in self.constr_dict_d.items()})
+        var_id_pos_set_r_ref = ray.put(var_id_pos_set_r)
+        var_id_pos_set_d_ref = ray.put(var_id_pos_set_d)
+
         # build actors with subproblems
         probs: list[ray.actor.ActorProxy[SubproblemsWrap]] = []
         for cpu in range(num_cpus):
             # get constraint idx for the group
             idx_r: list[int] = constrs_gps_idx_r[cpu::num_cpus].tolist()
             idx_d: list[int] = constrs_gps_idx_d[cpu::num_cpus].tolist()
-            # get constraints group
-            constrs_r = [self.constrs_gps_r[j] for j in idx_r]
-            constrs_d = [self.constrs_gps_d[j] for j in idx_d]
-            # get obj groups
-            obj_r = [obj_expr_r[j] for j in idx_r]
-            obj_d = [obj_expr_d[j] for j in idx_d]
-            # get var_id_to_pos_list
-            var_id_to_pos_r = [
-                [self.constr_dict_r[constr] for constr in constrs] for constrs in constrs_r
-            ]
-            var_id_to_pos_d = [
-                [self.constr_dict_d[constr] for constr in constrs] for constrs in constrs_d
-            ]
+
             # build subproblems
             actor = ray.remote(SubproblemsWrap).options(
                 scheduling_strategy=PlacementGroupSchedulingStrategy(
@@ -492,14 +511,14 @@ class Problem(CpProblem):
                 actor.remote(
                     idx_r,
                     idx_d,
-                    obj_r,
-                    obj_d,
-                    constrs_r,
-                    constrs_d,
-                    var_id_to_pos_r,
-                    var_id_to_pos_d,
-                    var_id_pos_set_r,
-                    var_id_pos_set_d,
+                    obj_expr_r_ref,
+                    obj_expr_d_ref,
+                    constrs_r_ref,
+                    constrs_d_ref,
+                    constr_dict_r_ref,
+                    constr_dict_d_ref,
+                    var_id_pos_set_r_ref,
+                    var_id_pos_set_d_ref,
                     rho,
                 )
             )

--- a/dede/subproblems_wrap.py
+++ b/dede/subproblems_wrap.py
@@ -17,16 +17,27 @@ class SubproblemsWrap:
         self,
         idx_r: list[int],
         idx_d: list[int],
-        obj_gps_r: t.Sequence[cp.Expression],
-        obj_gps_d: t.Sequence[cp.Expression],
-        constrs_gps_r: list[list[cp.Constraint]],
-        constrs_gps_d: list[list[cp.Constraint]],
-        var_id_to_pos_gps_r: list[list[list[VarInfoT]]],
-        var_id_to_pos_gps_d: list[list[list[VarInfoT]]],
+        obj_gps_r_full: t.Sequence[cp.Expression],
+        obj_gps_d_full: t.Sequence[cp.Expression],
+        constrs_gps_r_full: list[list[cp.Constraint]],
+        constrs_gps_d_full: list[list[cp.Constraint]],
+        constr_dict_r: dict[int, list[VarInfoT]],
+        constr_dict_d: dict[int, list[VarInfoT]],
         var_id_pos_set_r: set[VarInfoT],
         var_id_pos_set_d: set[VarInfoT],
         rho: float,
     ):
+        obj_gps_r = [obj_gps_r_full[i] for i in idx_r]
+        obj_gps_d = [obj_gps_d_full[i] for i in idx_d]
+        constrs_gps_r = [constrs_gps_r_full[i] for i in idx_r]
+        constrs_gps_d = [constrs_gps_d_full[i] for i in idx_d]
+        var_id_to_pos_gps_r = [
+            [constr_dict_r[constr.id] for constr in constrs] for constrs in constrs_gps_r
+        ]
+        var_id_to_pos_gps_d = [
+            [constr_dict_d[constr.id] for constr in constrs] for constrs in constrs_gps_d
+        ]
+
         # sort subproblem for better data locality
         self.probs_r: list[Subproblem] = []
         i: int

--- a/dede/subproblems_wrap.py
+++ b/dede/subproblems_wrap.py
@@ -15,8 +15,8 @@ class SubproblemsWrap:
 
     def __init__(
         self,
-        idx_r: list[int],
-        idx_d: list[int],
+        idx_r: NDArray[np.signedinteger],
+        idx_d: NDArray[np.signedinteger],
         obj_gps_r_full: t.Sequence[cp.Expression],
         obj_gps_d_full: t.Sequence[cp.Expression],
         constrs_gps_r_full: list[list[cp.Constraint]],
@@ -27,10 +27,10 @@ class SubproblemsWrap:
         var_id_pos_set_d: set[VarInfoT],
         rho: float,
     ):
-        obj_gps_r = [obj_gps_r_full[i] for i in idx_r]
-        obj_gps_d = [obj_gps_d_full[i] for i in idx_d]
-        constrs_gps_r = [constrs_gps_r_full[i] for i in idx_r]
-        constrs_gps_d = [constrs_gps_d_full[i] for i in idx_d]
+        obj_gps_r: list[cp.Expression] = [obj_gps_r_full[i] for i in idx_r]
+        obj_gps_d: list[cp.Expression] = [obj_gps_d_full[i] for i in idx_d]
+        constrs_gps_r: list[list[cp.Constraint]] = [constrs_gps_r_full[i] for i in idx_r]
+        constrs_gps_d: list[list[cp.Constraint]] = [constrs_gps_d_full[i] for i in idx_d]
         var_id_to_pos_gps_r = [
             [constr_dict_r[constr.id] for constr in constrs] for constrs in constrs_gps_r
         ]


### PR DESCRIPTION
- Serialize expensive objects exactly once and pass references to each subproblem, only pass the indices for each subproblem
- Add timing to all functions

From https://docs.ray.io/en/latest/ray-core/patterns/pass-large-arg-by-value.html

Before:
<img width="1219" height="44" alt="image" src="https://github.com/user-attachments/assets/c19eab92-d22d-4fb2-b32c-47e4320ac60c" />
After:
<img width="1516" height="331" alt="image" src="https://github.com/user-attachments/assets/4a72bc3c-2ee8-4b76-ba63-0712d3ad32f6" />

