### PR TITLE
Parallelize objective grouping, add logic for connecting to ray server

### DIFF
--- a/dede/problem.py
+++ b/dede/problem.py
@@ -8,6 +8,7 @@ import cvxpy as cp
 import numpy as np
 import ray
 import ray.actor
+import ray.exceptions
 from cvxpy.constraints.nonpos import Inequality
 from cvxpy.constraints.zero import Equality, Zero
 from cvxpy.problems.objective import Minimize
@@ -26,6 +27,41 @@ from .utils import (
 
 ObjectiveT = t.Union[cp.Maximize, cp.Minimize]
 ConstraintT = t.Union[Equality, Zero, Inequality]
+
+
+@contextlib.contextmanager
+def _get_distributed_pg(
+    max_cpus_per_node: int, timeout: float = 10.0
+) -> t.Iterator[PlacementGroup]:
+    """Returns a placement group that tries to spread
+    workers across all available nodes in the ray network.
+
+    Ideally used as a context manager to free up
+    the placement group once execution has finished.
+
+    Args:
+        max_cpus_per_node (int): how many CPUs to request per node. This is an upper bound on the
+        number of CPUs reserved.
+
+    Returns:
+        t.Iterator[PlacementGroup]: the placement group
+    """
+    nodes = [node for node in ray.nodes() if node["Alive"]]
+
+    bundles = [{"CPU": 1.0}] * min(max_cpus_per_node * len(nodes), _get_ray_cpus())
+    pg = ray.util.placement_group(bundles, strategy="SPREAD")
+    ray.get(pg.ready(), timeout=timeout)
+    try:
+        yield pg
+    finally:
+        ray.util.remove_placement_group(pg)
+
+
+def _get_ray_cpus() -> int:
+    """Get the true amount of cpus available in the ray cluster."""
+    if not ray.is_initialized():
+        raise RuntimeError("Ray is not initialized. Cannot get number of CPUs in the cluster.")
+    return int(ray.cluster_resources().get("CPU", 1))
 
 
 class RaySubprobCache:
@@ -81,11 +117,14 @@ class RaySubprobCache:
         else:
             ray.init(num_cpus=user_num_cpus)
 
-        self._placement_group = ray.util.placement_group(
-            [{"CPU": 1}] * (user_num_cpus or self._get_ray_cpus())
-        )
-
         return True
+
+    def reserve_placement_group(self, timeout: float = 10.0) -> PlacementGroup:
+        if self._placement_group is not None:
+            raise RuntimeError("Reserving another placement group when one is already reserved")
+        self._placement_group = ray.util.placement_group([{"CPU": 1}] * (self.num_cpus))
+        ray.get(self._placement_group.ready(), timeout=timeout)
+        return self._placement_group
 
     def set_subprobs(
         self,
@@ -108,12 +147,6 @@ class RaySubprobCache:
             ray.util.remove_placement_group(self._placement_group)
         self._placement_group = None
 
-    def _get_ray_cpus(self) -> int:
-        """Get the true amount of cpus available in the ray cluster."""
-        if not ray.is_initialized():
-            raise RuntimeError("Ray is not initialized. Cannot get number of CPUs in the cluster.")
-        return int(ray.cluster_resources().get("CPU", 1))
-
     @property
     def rho(self) -> float:
         if self._rho is None:
@@ -125,7 +158,7 @@ class RaySubprobCache:
         """Get the number of CPUs the user requested.
         In the case of None, defauls to all available CPUs."""
         if self._user_num_cpus is None:
-            return self._get_ray_cpus()
+            return _get_ray_cpus()
         return self._user_num_cpus
 
     @property
@@ -154,34 +187,10 @@ class RaySubprobCache:
 
     @property
     def placement_group(self) -> PlacementGroup:
+        """Get a placement group with the requested number of CPUs."""
         if self._placement_group is None:
-            raise RuntimeError("placement_group is not set")
+            raise RuntimeError("placement group is not set")
         return self._placement_group
-
-    @contextlib.contextmanager
-    def get_distributed_pg(self, max_cpus_per_node: int) -> t.Iterator[PlacementGroup]:
-        """Returns a placement group that tries to spread
-        workers across all available nodes in the ray network.
-
-        Ideally used as a context manager to free up
-        the placement group once execution has finished.
-
-        Args:
-            max_cpus_per_node (int): how many CPUs to request per node. This may not be fulfilled
-            if some node does not have enough available CPUs.
-
-        Returns:
-            t.Iterator[PlacementGroup]: the placement group
-        """
-        nodes = [node for node in ray.nodes() if node["Alive"]]
-
-        bundles = [{"CPU": 1.0}] * min(max_cpus_per_node * len(nodes), self.num_cpus)
-        pg = ray.util.placement_group(bundles, strategy="SPREAD")
-        ray.get(pg.ready())
-        try:
-            yield pg
-        finally:
-            ray.util.remove_placement_group(pg)
 
 
 class Problem(CpProblem):
@@ -297,10 +306,13 @@ class Problem(CpProblem):
         if subproblems_invalidated:
             # store subproblem in last solution
             obj_expr_r, obj_expr_d = self._get_grouped_objectives()
+            # reserve the actors needed to create the subproblems
+            self._subprob_cache.reserve_placement_group()
             probs = self.get_subproblems(obj_expr_r, obj_expr_d, self._subprob_cache.num_cpus, rho)
 
             # store parameter index in z solutions for x problems
             param_idx_r, param_idx_d = self._get_param_idx(probs)
+
             self._subprob_cache.set_subprobs(probs, param_idx_r, param_idx_d)
 
             # get demand solution
@@ -550,7 +562,7 @@ class Problem(CpProblem):
 
         # use a placement group with strategy = SPREAD due to the diminishing returns
         # observed with larger numbers of CPUs
-        with self._subprob_cache.get_distributed_pg(4) as pg:
+        with _get_distributed_pg(4) as pg:
             var_id_pos_to_idx: dict[VarInfoT, list[tuple[int, int]]] = defaultdict(list)
             for i, constrs_gps, constr_dict in zip(
                 [0, 1],

--- a/dede/problem.py
+++ b/dede/problem.py
@@ -272,12 +272,9 @@ class Problem(CpProblem):
     ) -> np.floating[t.Any]:
         """Compiles and solves the original problem.
 
-        Ray must be initialized before calling this method with enable_dede=True
-        or it will run using only one CPU.
-
         Args:
-            num_cpus: number of CPUs to use; if None, use all available CPUs. If ray_address
-            is not None or ray is already initialized, this argument must be None.
+            num_cpus: number of CPUs to use; if None, use all available CPUs.
+                If more than the available number of CPUs, will error.
             ray_address: ray cluster address; if None, will use local ray instance.
             enable_dede: whether to decouple and decompose with DeDe
             rho: rho value in ADMM; 1 by default

--- a/dede/problem.py
+++ b/dede/problem.py
@@ -551,6 +551,8 @@ class Problem(CpProblem):
         if self._obj_expr_r is not None and self._obj_expr_d is not None:
             return self._obj_expr_r, self._obj_expr_d
 
+        # use a placement group with strategy = SPREAD due to the diminishing returns
+        # observed with larger numbers of CPUs
         with self._subprob_cache.get_distributed_pg(4) as pg:
             var_id_pos_to_idx: dict[VarInfoT, list[tuple[int, int]]] = defaultdict(list)
             for i, constrs_gps, constr_dict in zip(

--- a/dede/problem.py
+++ b/dede/problem.py
@@ -478,13 +478,12 @@ class Problem(CpProblem):
         dict_ref = ray.put(dict(var_id_pos_to_idx))
 
         # chunk the indices to split the work
-        chunks = np.array_split(np.arange(len(expr_list)), num_cpus)
+        chunks = np.array_split(np.arange(len(expr_list), dtype=np.int64), num_cpus)
 
         # send the chunks to the remote function for processing
         futures = [
             _process_obj_chunk_indices.remote(
-                c[0],
-                c[-1] + 1,
+                c,
                 expr_ref,
                 self._solver,
                 dict_ref,
@@ -520,8 +519,7 @@ class Problem(CpProblem):
 
 @ray.remote
 def _process_obj_chunk_indices(
-    start: int,
-    end: int,
+    indices: NDArray[np.int64],
     expr_list_ref: list[cp.Expression],
     solver: str,
     var_id_pos_to_idx: dict[VarInfoT, list[tuple[int, int]]],
@@ -535,7 +533,7 @@ def _process_obj_chunk_indices(
     local_r_idx: list[list[int]] = [[] for _ in range(num_r)]
     local_d_idx: list[list[int]] = [[] for _ in range(num_d)]
 
-    for idx in range(start, end):
+    for idx in indices:
         # Access the object from the shared reference
         obj = expr_list_ref[idx]
 

--- a/dede/problem.py
+++ b/dede/problem.py
@@ -45,6 +45,21 @@ class RaySubprobCache:
         self._placement_group: t.Optional[PlacementGroup] = None
 
     def update_cache(self, rho: float, user_num_cpus: t.Optional[int], ray_address: str) -> bool:
+        """Updates the execution parameters stored in the cache.
+
+        If this results in cache invalidation, the subproblem settings need to be set again.
+
+        Args:
+            rho (float): the rho to use in optimization
+            user_num_cpus (t.Optional[int]): how many CPUs to use in optimization. None means all
+                available CPUs will be used.
+            ray_address (str): the address of the ray server to connect to.
+                Either "local" or an ip address.
+
+        Returns:
+            bool: True if the cache was invalidated as part of the update
+            (i.e., there was a change). Otherwise, False.
+        """
         # we want to rebuild subproblems and restart ray if
         # the rho changes, the address or changes, or the num cpus changes in local mode
         if not (
@@ -78,6 +93,7 @@ class RaySubprobCache:
         param_idx_r: list[list[int]],
         param_idx_d: list[list[int]],
     ) -> None:
+        """Stores subproblems in the cache (subproblems, indices of parameters)."""
         self._probs = probs
         self._param_idx_r = param_idx_r
         self._param_idx_d = param_idx_d
@@ -93,9 +109,7 @@ class RaySubprobCache:
         self._placement_group = None
 
     def _get_ray_cpus(self) -> int:
-        """Get the true amount of cpus available in the ray cluster.
-        This only differs from the user inputted when when the user input is None,
-        which indicates that all CPUs should be used."""
+        """Get the true amount of cpus available in the ray cluster."""
         if not ray.is_initialized():
             raise RuntimeError("Ray is not initialized. Cannot get number of CPUs in the cluster.")
         return int(ray.cluster_resources().get("CPU", 1))
@@ -108,6 +122,8 @@ class RaySubprobCache:
 
     @property
     def num_cpus(self) -> int:
+        """Get the number of CPUs the user requested.
+        In the case of None, defauls to all available CPUs."""
         if self._user_num_cpus is None:
             return self._get_ray_cpus()
         return self._user_num_cpus
@@ -144,6 +160,19 @@ class RaySubprobCache:
 
     @contextlib.contextmanager
     def get_distributed_pg(self, max_cpus_per_node: int) -> t.Iterator[PlacementGroup]:
+        """Returns a placement group that tries to spread
+        workers across all available nodes in the ray network.
+
+        Ideally used as a context manager to free up
+        the placement group once execution has finished.
+
+        Args:
+            max_cpus_per_node (int): how many CPUs to request per node. This may not be fulfilled
+            if some node does not have enough available CPUs.
+
+        Returns:
+            t.Iterator[PlacementGroup]: the placement group
+        """
         nodes = [node for node in ray.nodes() if node["Alive"]]
 
         bundles = [{"CPU": 1.0}] * min(max_cpus_per_node * len(nodes), self.num_cpus)

--- a/dede/problem.py
+++ b/dede/problem.py
@@ -31,9 +31,13 @@ class SubprobCache:
     """Cache subproblems."""
 
     def __init__(self):
+        # these three fields reflect user-passed arguments
         self.rho: t.Optional[float] = None
-        self.num_cpus: t.Optional[int] = None
+        # this does not necessarily reflect the true number of cpus
+        # in the ray cluster if the user inputted None (i.e., use max)
+        self.user_num_cpus: t.Optional[int] = None
         self.address: t.Optional[str] = None
+
         self.probs: t.Optional[list[ray.actor.ActorProxy[SubproblemsWrap]]] = None
         self.param_idx_r: list[list[int]] = []
         self.param_idx_d: list[list[int]] = []
@@ -45,14 +49,23 @@ class SubprobCache:
         self.param_idx_r, self.param_idx_d = [], []
 
     @property
+    def ray_cpus(self) -> int:
+        """Get the true amount of cpus available in the ray cluster.
+        This only differs from the user inputted when when the user input is None,
+        which indicates that all CPUs should be used."""
+        if not ray.is_initialized():
+            raise RuntimeError("Ray is not initialized. Cannot get number of CPUs in the cluster.")
+        return int(ray.cluster_resources().get("CPU", 1))
+
+    @property
     def key(self) -> t.Optional[KeyT]:
         if self.rho is None or self.num_cpus is None or self.address is None:
             return None
         return (self.rho, self.num_cpus, self.address)
 
     @classmethod
-    def make_key(cls, rho: float, num_cpus: int, address: str) -> KeyT:
-        return (rho, num_cpus, address)
+    def make_key(cls, rho: float, user_num_cpus: int, address: str) -> KeyT:
+        return (rho, user_num_cpus, address)
 
 
 class Problem(CpProblem):
@@ -133,7 +146,7 @@ class Problem(CpProblem):
 
     def solve(
         self,
-        num_cpus: int = os.cpu_count() or 1,
+        num_cpus: t.Optional[int] = None,
         ray_address: str = "local",
         enable_dede: bool = True,
         rho: float = 1.0,
@@ -148,8 +161,7 @@ class Problem(CpProblem):
 
         Args:
             num_cpus: number of CPUs to use; if None, use all available CPUs. If ray_address
-            is not None or ray is already initialized, this argument will be ignored and the
-            number of CPUs available in the ray cluster will be used.
+            is not None or ray is already initialized, this argument must be None.
             ray_address: ray cluster address; if None, will use local ray instance.
             enable_dede: whether to decouple and decompose with DeDe
             rho: rho value in ADMM; 1 by default
@@ -165,8 +177,10 @@ class Problem(CpProblem):
             coeff = 1 if self._problem_type == Minimize else -1
             return t.cast(np.floating[t.Any], coeff * self.value)
 
-        if num_cpus > (os.cpu_count() or 1):
+        if num_cpus is not None and num_cpus > (os.cpu_count() or 1):
             raise ValueError(f"{num_cpus} CPUs exceeds upper limit of {os.cpu_count()}.")
+        if ray_address != "local" and num_cpus is not None:
+            raise ValueError("Cannot specify num_cpus when using non-local ray cluster.")
 
         # we want to rebuild subproblems and restart ray if
         # the rho changes, the address or changes, or the num cpus changes in local mode
@@ -183,21 +197,17 @@ class Problem(CpProblem):
             else:
                 ray.init(num_cpus=num_cpus)
 
-            # get true amount of cpus available in ray cluster
-            num_cpus = int(ray.cluster_resources().get("CPU", 1))
-
             # invalidate old settings
             # this is necessary since ray restarted, which made the old subproblems tied to the
             # old ray instance invalid
             self._subprob_cache.invalidate()
             self._subprob_cache.rho = rho
 
-            # initialize ray
-            self._subprob_cache.num_cpus = num_cpus
-
             # store subproblem in last solution
-            obj_expr_r, obj_expr_d = self._get_grouped_objectives(num_cpus)
-            self._subprob_cache.probs = self.get_subproblems(obj_expr_r, obj_expr_d, num_cpus, rho)
+            obj_expr_r, obj_expr_d = self._get_grouped_objectives(self._subprob_cache.ray_cpus)
+            self._subprob_cache.probs = self.get_subproblems(
+                obj_expr_r, obj_expr_d, self._subprob_cache.ray_cpus, rho
+            )
 
             # store parameter index in z solutions for x problems
             self._subprob_cache.param_idx_r, self._subprob_cache.param_idx_d = self.get_param_idx()
@@ -444,6 +454,9 @@ class Problem(CpProblem):
         self, num_cpus: int
     ) -> tuple[list[cp.Expression], list[cp.Expression]]:
         """Split objective into corresponding constraint groups"""
+
+        # See if the grouped objectives are already computed and cached.
+        # If so, return them to avoid redundant computation.
         if self._obj_expr_r is not None and self._obj_expr_d is not None:
             return self._obj_expr_r, self._obj_expr_d
 

--- a/dede/problem.py
+++ b/dede/problem.py
@@ -1,3 +1,4 @@
+import contextlib
 import os
 import time
 import typing as t
@@ -12,6 +13,7 @@ from cvxpy.constraints.zero import Equality, Zero
 from cvxpy.problems.objective import Minimize
 from cvxpy.problems.problem import Problem as CpProblem
 from numpy.typing import NDArray
+from ray.util.placement_group import PlacementGroup
 
 from .constraints_utils import breakdown_constr
 from .subproblems_wrap import SubproblemsWrap
@@ -22,34 +24,75 @@ from .utils import (
     get_var_id_pos_list_from_linear,
 )
 
-KeyT = tuple[float, int, str]
 ObjectiveT = t.Union[cp.Maximize, cp.Minimize]
 ConstraintT = t.Union[Equality, Zero, Inequality]
 
 
-class SubprobCache:
+class RaySubprobCache:
     """Cache subproblems."""
 
     def __init__(self):
         # these three fields reflect user-passed arguments
-        self.rho: t.Optional[float] = None
+        self._rho: t.Optional[float] = None
         # this does not necessarily reflect the true number of cpus
         # in the ray cluster if the user inputted None (i.e., use max)
-        self.user_num_cpus: t.Optional[int] = None
-        self.address: t.Optional[str] = None
+        self._user_num_cpus: t.Optional[int] = None
+        self._address: t.Optional[str] = None
 
-        self.probs: t.Optional[list[ray.actor.ActorProxy[SubproblemsWrap]]] = None
-        self.param_idx_r: list[list[int]] = []
-        self.param_idx_d: list[list[int]] = []
+        self._probs: t.Optional[list[ray.actor.ActorProxy[SubproblemsWrap]]] = None
+        self._param_idx_r: list[list[int]] = []
+        self._param_idx_d: list[list[int]] = []
+        self._placement_group: t.Optional[PlacementGroup] = None
 
-    def invalidate(self):
-        self.rho = None
-        self.num_cpus = None
-        self.probs = None
-        self.param_idx_r, self.param_idx_d = [], []
+    def update_cache(self, rho: float, user_num_cpus: t.Optional[int], ray_address: str) -> bool:
+        # we want to rebuild subproblems and restart ray if
+        # the rho changes, the address or changes, or the num cpus changes in local mode
+        if not (
+            rho != self._rho
+            or ray_address != self._address
+            or (ray_address == "local" and user_num_cpus != self._user_num_cpus)
+            or not ray.is_initialized()
+        ):
+            return False
 
-    @property
-    def ray_cpus(self) -> int:
+        self._invalidate()
+        self._rho = rho
+        self._user_num_cpus = user_num_cpus
+        self._address = ray_address
+
+        ray.shutdown()
+        if ray_address != "local":
+            ray.init(address=ray_address)
+        else:
+            ray.init(num_cpus=user_num_cpus)
+
+        self._placement_group = ray.util.placement_group(
+            [{"CPU": 1}] * (user_num_cpus or self._get_ray_cpus())
+        )
+
+        return True
+
+    def set_subprobs(
+        self,
+        probs: list[ray.actor.ActorProxy[SubproblemsWrap]],
+        param_idx_r: list[list[int]],
+        param_idx_d: list[list[int]],
+    ) -> None:
+        self._probs = probs
+        self._param_idx_r = param_idx_r
+        self._param_idx_d = param_idx_d
+
+    def _invalidate(self):
+        self._rho = None
+        self._user_num_cpus = None
+        self._address = None
+        self._probs = None
+        self._param_idx_r, self._param_idx_d = [], []
+        if self._placement_group is not None and ray.is_initialized():
+            ray.util.remove_placement_group(self._placement_group)
+        self._placement_group = None
+
+    def _get_ray_cpus(self) -> int:
         """Get the true amount of cpus available in the ray cluster.
         This only differs from the user inputted when when the user input is None,
         which indicates that all CPUs should be used."""
@@ -58,14 +101,58 @@ class SubprobCache:
         return int(ray.cluster_resources().get("CPU", 1))
 
     @property
-    def key(self) -> t.Optional[KeyT]:
-        if self.rho is None or self.num_cpus is None or self.address is None:
-            return None
-        return (self.rho, self.num_cpus, self.address)
+    def rho(self) -> float:
+        if self._rho is None:
+            raise RuntimeError("rho is not set")
+        return self._rho
 
-    @classmethod
-    def make_key(cls, rho: float, user_num_cpus: int, address: str) -> KeyT:
-        return (rho, user_num_cpus, address)
+    @property
+    def num_cpus(self) -> int:
+        if self._user_num_cpus is None:
+            return self._get_ray_cpus()
+        return self._user_num_cpus
+
+    @property
+    def address(self) -> str:
+        if self._address is None:
+            raise RuntimeError("address is not set")
+        return self._address
+
+    @property
+    def probs(self) -> list[ray.actor.ActorProxy[SubproblemsWrap]]:
+        if self._probs is None:
+            raise RuntimeError("probs is not set")
+        return self._probs
+
+    @property
+    def param_idx_r(self) -> list[list[int]]:
+        if not self._param_idx_r:
+            raise RuntimeError("param_idx_r is not set")
+        return self._param_idx_r
+
+    @property
+    def param_idx_d(self) -> list[list[int]]:
+        if not self._param_idx_d:
+            raise RuntimeError("param_idx_d is not set")
+        return self._param_idx_d
+
+    @property
+    def placement_group(self) -> PlacementGroup:
+        if self._placement_group is None:
+            raise RuntimeError("placement_group is not set")
+        return self._placement_group
+
+    @contextlib.contextmanager
+    def get_distributed_pg(self, max_cpus_per_node: int) -> t.Iterator[PlacementGroup]:
+        nodes = [node for node in ray.nodes() if node["Alive"]]
+
+        bundles = [{"CPU": 1.0}] * min(max_cpus_per_node * len(nodes), self.num_cpus)
+        pg = ray.util.placement_group(bundles, strategy="SPREAD")
+        ray.get(pg.ready())
+        try:
+            yield pg
+        finally:
+            ray.util.remove_placement_group(pg)
 
 
 class Problem(CpProblem):
@@ -93,7 +180,7 @@ class Problem(CpProblem):
         self._constrs_d = breakdown_constr(constrs_d_converted, 1)
 
         # init subprob cache
-        self._subprob_cache = SubprobCache()
+        self._subprob_cache = RaySubprobCache()
 
         # keep track of original problem type
         self._problem_type = type(objective)
@@ -179,44 +266,19 @@ class Problem(CpProblem):
 
         if num_cpus is not None and num_cpus > (os.cpu_count() or 1):
             raise ValueError(f"{num_cpus} CPUs exceeds upper limit of {os.cpu_count()}.")
-        if ray_address != "local" and num_cpus is not None:
-            raise ValueError("Cannot specify num_cpus when using non-local ray cluster.")
 
-        # we want to rebuild subproblems and restart ray if
-        # the rho changes, the address or changes, or the num cpus changes in local mode
-        if (
-            rho != self._subprob_cache.rho
-            or ray_address != self._subprob_cache.address
-            or (ray_address == "local" and num_cpus != self._subprob_cache.num_cpus)
-            or not ray.is_initialized()
-        ):
-            # restart ray, this is necessary since for changing num cpus or address
-            ray.shutdown()
-            if ray_address != "local":
-                ray.init(address=ray_address)
-            else:
-                ray.init(num_cpus=num_cpus)
-
-            # invalidate old settings
-            # this is necessary since ray restarted, which made the old subproblems tied to the
-            # old ray instance invalid
-            self._subprob_cache.invalidate()
-            self._subprob_cache.rho = rho
-
+        subproblems_invalidated = self._subprob_cache.update_cache(rho, num_cpus, ray_address)
+        if subproblems_invalidated:
             # store subproblem in last solution
-            obj_expr_r, obj_expr_d = self._get_grouped_objectives(self._subprob_cache.ray_cpus)
-            self._subprob_cache.probs = self.get_subproblems(
-                obj_expr_r, obj_expr_d, self._subprob_cache.ray_cpus, rho
-            )
+            obj_expr_r, obj_expr_d = self._get_grouped_objectives()
+            probs = self.get_subproblems(obj_expr_r, obj_expr_d, self._subprob_cache.num_cpus, rho)
 
             # store parameter index in z solutions for x problems
-            self._subprob_cache.param_idx_r, self._subprob_cache.param_idx_d = self.get_param_idx()
-            # get demand solution
-            self.sol_d = np.hstack(
-                ray.get([prob.get_solution_d.remote() for prob in self._subprob_cache.probs])
-            )
+            param_idx_r, param_idx_d = self.get_param_idx()
+            self._subprob_cache.set_subprobs(probs, param_idx_r, param_idx_d)
 
-        assert self._subprob_cache.probs is not None
+            # get demand solution
+            self.sol_d = np.hstack(ray.get([prob.get_solution_d.remote() for prob in probs]))
 
         # update parameter values
         param_id_to_value = {
@@ -283,8 +345,6 @@ class Problem(CpProblem):
         var_id_to_var = {var.id: var for var in self.variables()}
         for var in self.variables():
             var.value = np.zeros(var.shape)
-
-        assert self._subprob_cache.probs is not None
 
         local_sol_idx: list[list[VarInfoT]] = ray.get(
             [prob.get_local_solution_idx.remote() for prob in self._subprob_cache.probs]
@@ -396,7 +456,10 @@ class Problem(CpProblem):
                 [self.constr_dict_d[constr] for constr in constrs] for constrs in constrs_d
             ]
             # build subproblems
-            actor = ray.remote(SubproblemsWrap)
+            actor = ray.remote(SubproblemsWrap).options(
+                placement_group=self._subprob_cache.placement_group,
+                placement_group_bundle_index=cpu,
+            )
             probs.append(
                 actor.remote(
                     idx_r,
@@ -416,8 +479,6 @@ class Problem(CpProblem):
 
     def get_param_idx(self) -> tuple[list[list[int]], list[list[int]]]:
         """Get parameter z index in last solution."""
-        assert self._subprob_cache.probs is not None
-
         # map var_id_pos in the big resource solution list
         sol_idx_r: list[list[VarInfoT]] = ray.get(
             [prob.get_solution_idx_r.remote() for prob in self._subprob_cache.probs]
@@ -450,9 +511,7 @@ class Problem(CpProblem):
         ]
         return param_idx_r, param_idx_d
 
-    def _get_grouped_objectives(
-        self, num_cpus: int
-    ) -> tuple[list[cp.Expression], list[cp.Expression]]:
+    def _get_grouped_objectives(self) -> tuple[list[cp.Expression], list[cp.Expression]]:
         """Split objective into corresponding constraint groups"""
 
         # See if the grouped objectives are already computed and cached.
@@ -460,41 +519,44 @@ class Problem(CpProblem):
         if self._obj_expr_r is not None and self._obj_expr_d is not None:
             return self._obj_expr_r, self._obj_expr_d
 
-        var_id_pos_to_idx: dict[VarInfoT, list[tuple[int, int]]] = defaultdict(list)
-        for i, constrs_gps, constr_dict in zip(
-            [0, 1],
-            [self.constrs_gps_r, self.constrs_gps_d],
-            [self.constr_dict_r, self.constr_dict_d],
-        ):
-            for j, constrs in enumerate(constrs_gps):
-                for constr in constrs:
-                    for var_id_pos in constr_dict[constr]:
-                        var_id_pos_to_idx[var_id_pos].append((i, j))
+        with self._subprob_cache.get_distributed_pg(4) as pg:
+            var_id_pos_to_idx: dict[VarInfoT, list[tuple[int, int]]] = defaultdict(list)
+            for i, constrs_gps, constr_dict in zip(
+                [0, 1],
+                [self.constrs_gps_r, self.constrs_gps_d],
+                [self.constr_dict_r, self.constr_dict_d],
+            ):
+                for j, constrs in enumerate(constrs_gps):
+                    for constr in constrs:
+                        for var_id_pos in constr_dict[constr]:
+                            var_id_pos_to_idx[var_id_pos].append((i, j))
 
-        expr_list = expand_expr(self.objective.expr)
+            expr_list = expand_expr(self.objective.expr)
 
-        # put heavy objects in shared memory to avoid serialization overhead
-        expr_ref = ray.put(expr_list)
-        dict_ref = ray.put(dict(var_id_pos_to_idx))
+            # put heavy objects in shared memory to avoid serialization overhead
+            expr_ref = ray.put(expr_list)
+            dict_ref = ray.put(dict(var_id_pos_to_idx))
 
-        # chunk the indices to split the work
-        chunks = np.array_split(np.arange(len(expr_list), dtype=np.int64), num_cpus)
+            # chunk the indices to split the work
+            chunks = np.array_split(np.arange(len(expr_list), dtype=np.int64), len(pg.bundle_specs))
 
-        # send the chunks to the remote function for processing
-        futures = [
-            _process_obj_chunk_indices.remote(
-                c,
-                expr_ref,
-                self._solver,
-                dict_ref,
-                len(self.constrs_gps_r),
-                len(self.constrs_gps_d),
-            )
-            for c in chunks
-        ]
+            # send the chunks to the remote function for processing
+            futures = [
+                _process_obj_chunk_indices.options(
+                    placement_group=pg, placement_group_bundle_index=i
+                ).remote(
+                    c,
+                    expr_ref,
+                    self._solver,
+                    dict_ref,
+                    len(self.constrs_gps_r),
+                    len(self.constrs_gps_d),
+                )
+                for i, c in enumerate(chunks)
+            ]
 
-        # block on results
-        results = ray.get(futures)
+            # block on results
+            results = ray.get(futures)
 
         # reconstruct groups
         obj_r: list[cp.Expression] = []
@@ -514,7 +576,7 @@ class Problem(CpProblem):
 
         self._obj_expr_r, self._obj_expr_d = obj_r, obj_d
 
-        return obj_r, obj_d
+        return self._obj_expr_r, self._obj_expr_d
 
 
 @ray.remote

--- a/dede/problem.py
+++ b/dede/problem.py
@@ -8,7 +8,6 @@ import cvxpy as cp
 import numpy as np
 import ray
 import ray.actor
-import ray.exceptions
 from cvxpy.constraints.nonpos import Inequality
 from cvxpy.constraints.zero import Equality, Zero
 from cvxpy.problems.objective import Minimize

--- a/dede/problem.py
+++ b/dede/problem.py
@@ -478,13 +478,13 @@ class Problem(CpProblem):
         dict_ref = ray.put(dict(var_id_pos_to_idx))
 
         # chunk the indices to split the work
-        indices = list(range(len(expr_list)))
-        chunks = np.array_split(indices, num_cpus)
+        chunks = np.array_split(np.arange(len(expr_list)), num_cpus)
 
         # send the chunks to the remote function for processing
         futures = [
             _process_obj_chunk_indices.remote(
-                c.tolist(),
+                c[0],
+                c[-1] + 1,
                 expr_ref,
                 self._solver,
                 dict_ref,
@@ -495,7 +495,7 @@ class Problem(CpProblem):
         ]
 
         # block on results
-        results = [ray.get(f) for f in futures]
+        results = ray.get(futures)
 
         # reconstruct groups
         obj_r: list[cp.Expression] = []
@@ -520,7 +520,8 @@ class Problem(CpProblem):
 
 @ray.remote
 def _process_obj_chunk_indices(
-    chunk_indices: list[int],
+    start: int,
+    end: int,
     expr_list_ref: list[cp.Expression],
     solver: str,
     var_id_pos_to_idx: dict[VarInfoT, list[tuple[int, int]]],
@@ -534,7 +535,7 @@ def _process_obj_chunk_indices(
     local_r_idx: list[list[int]] = [[] for _ in range(num_r)]
     local_d_idx: list[list[int]] = [[] for _ in range(num_d)]
 
-    for idx in chunk_indices:
+    for idx in range(start, end):
         # Access the object from the shared reference
         obj = expr_list_ref[idx]
 

--- a/dede/problem.py
+++ b/dede/problem.py
@@ -274,7 +274,7 @@ class Problem(CpProblem):
             probs = self.get_subproblems(obj_expr_r, obj_expr_d, self._subprob_cache.num_cpus, rho)
 
             # store parameter index in z solutions for x problems
-            param_idx_r, param_idx_d = self.get_param_idx()
+            param_idx_r, param_idx_d = self._get_param_idx(probs)
             self._subprob_cache.set_subprobs(probs, param_idx_r, param_idx_d)
 
             # get demand solution
@@ -477,11 +477,14 @@ class Problem(CpProblem):
             )
         return probs
 
-    def get_param_idx(self) -> tuple[list[list[int]], list[list[int]]]:
+    @classmethod
+    def _get_param_idx(
+        cls, probs: list[ray.actor.ActorProxy[SubproblemsWrap]]
+    ) -> tuple[list[list[int]], list[list[int]]]:
         """Get parameter z index in last solution."""
         # map var_id_pos in the big resource solution list
         sol_idx_r: list[list[VarInfoT]] = ray.get(
-            [prob.get_solution_idx_r.remote() for prob in self._subprob_cache.probs]
+            [prob.get_solution_idx_r.remote() for prob in probs]
         )
 
         sol_idx_dict_r: dict[VarInfoT, int] = {}
@@ -493,7 +496,7 @@ class Problem(CpProblem):
 
         # map var_id_pos in the big demand solution list
         sol_idx_d: list[list[VarInfoT]] = ray.get(
-            [prob.get_solution_idx_d.remote() for prob in self._subprob_cache.probs]
+            [prob.get_solution_idx_d.remote() for prob in probs]
         )
         sol_idx_dict_d: dict[VarInfoT, int] = {}
         idx = 0

--- a/dede/problem.py
+++ b/dede/problem.py
@@ -1,5 +1,4 @@
 import contextlib
-import os
 import time
 import typing as t
 from collections import defaultdict
@@ -116,6 +115,9 @@ class RaySubprobCache:
             ray.init(address=ray_address)
         else:
             ray.init(num_cpus=user_num_cpus)
+
+        if user_num_cpus is not None and user_num_cpus > _get_ray_cpus():
+            raise ValueError(f"Too many CPUs requested, only have {_get_ray_cpus()} available")
 
         return True
 
@@ -298,9 +300,6 @@ class Problem(CpProblem):
 
             coeff = 1 if self._problem_type == Minimize else -1
             return t.cast(np.floating[t.Any], coeff * self.value)
-
-        if num_cpus is not None and num_cpus > (os.cpu_count() or 1):
-            raise ValueError(f"{num_cpus} CPUs exceeds upper limit of {os.cpu_count()}.")
 
         subproblems_invalidated = self._subprob_cache.update_cache(rho, num_cpus, ray_address)
         if subproblems_invalidated:

--- a/dede/problem.py
+++ b/dede/problem.py
@@ -289,7 +289,7 @@ class Problem(CpProblem):
         local_sol_idx: list[list[VarInfoT]] = ray.get(
             [prob.get_local_solution_idx.remote() for prob in self._subprob_cache.probs]
         )
-        local_sol: list[NDArray[np.floating[t.Any]]] = ray.get(
+        local_sol: list[list[np.floating[t.Any]]] = ray.get(
             [prob.get_local_solution.remote() for prob in self._subprob_cache.probs]
         )
         flat_local_idx = [idx for arr in local_sol_idx for idx in arr]

--- a/dede/problem.py
+++ b/dede/problem.py
@@ -14,6 +14,7 @@ from cvxpy.problems.objective import Minimize
 from cvxpy.problems.problem import Problem as CpProblem
 from numpy.typing import NDArray
 from ray.util.placement_group import PlacementGroup
+from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
 
 from .constraints_utils import breakdown_constr
 from .subproblems_wrap import SubproblemsWrap
@@ -494,8 +495,10 @@ class Problem(CpProblem):
             ]
             # build subproblems
             actor = ray.remote(SubproblemsWrap).options(
-                placement_group=self._subprob_cache.placement_group,
-                placement_group_bundle_index=cpu,
+                scheduling_strategy=PlacementGroupSchedulingStrategy(
+                    placement_group=self._subprob_cache.placement_group,
+                    placement_group_bundle_index=cpu,
+                )
             )
             probs.append(
                 actor.remote(
@@ -585,7 +588,10 @@ class Problem(CpProblem):
             # send the chunks to the remote function for processing
             futures = [
                 _process_obj_chunk_indices.options(
-                    placement_group=pg, placement_group_bundle_index=i
+                    scheduling_strategy=PlacementGroupSchedulingStrategy(
+                        placement_group=pg,
+                        placement_group_bundle_index=i,
+                    )
                 ).remote(
                     c,
                     expr_ref,

--- a/dede/subproblems_wrap.py
+++ b/dede/subproblems_wrap.py
@@ -100,7 +100,7 @@ class SubproblemsWrap:
         return [idx for prob in probs for idx in prob.get_local_solution_idx()]
 
     @ray.method
-    def get_local_solution(self) -> list[NDArray[np.floating[t.Any]]]:
+    def get_local_solution(self) -> list[np.floating[t.Any]]:
         """Get concatenated solution of all local-only variables."""
         probs = self.probs_r + self.probs_d
         return [sol for prob in probs for sol in prob.get_local_solution()]


### PR DESCRIPTION
- Moved grouping objective logic to the solve stage, and made it use ray (with spread strategy) for parallelization (it previously was very slow due to serial executions of get_var_id_pos_list_from_cone)
- Added address to solve parameters & integrated it into subproblem cache, this allows the solver to connect to a multi-machine ray network instead of being purely local
- Reworked SubprobCache to better encapsulate ray logic