### PR TITLE
Fix bug in expand expr

### DIFF
--- a/dede/utils.py
+++ b/dede/utils.py
@@ -58,8 +58,14 @@ def expand_expr(expr: cp.Expression) -> list[cp.Expression]:
         return [Sum(new_expr) for new_expr in expand_expr(expr.args[0])]
     # (sum_{ij}X^2_{ij})/y
     elif isinstance(expr, quad_over_lin):
+        if len(expr.args[0].shape) == 0:
+            # don't element-wise expand a scalar since that is different semantically
+            return [expr]
         return [quad_over_lin(new_expr, expr.args[1]) for new_expr in expand_expr(expr.args[0])]
     elif isinstance(expr, log):
+        if len(expr.args[0].shape) == 0:
+            # don't element-wise expand a scalar since that is different semantically
+            return [expr]
         return [log(new_expr) for new_expr in expand_expr(expr.args[0])]
     elif isinstance(expr, trace):
         return [expr.args[0][i, i] for i in range(expr.args[0].shape[0])]

--- a/tests/test_solution.py
+++ b/tests/test_solution.py
@@ -188,8 +188,8 @@ def test_nested_log():
     prob = dd.Problem(objective, resource_constraints, demand_constraints)
     result_dede = prob.solve(num_cpus=2, solver=dd.ECOS)
 
-    cvxpy_prob = cp.Problem(objective, resource_constraints + demand_constraints, solver=dd.ECOs)
-    result_cvxpy = cvxpy_prob.solve()
+    cvxpy_prob = cp.Problem(objective, resource_constraints + demand_constraints)
+    result_cvxpy = cvxpy_prob.solve(solver=dd.ECOS)
 
     assert check_solution(result_dede, result_cvxpy, objective)
 

--- a/tests/test_solution.py
+++ b/tests/test_solution.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import cvxpy as cp
 import numpy as np
 from conftest import GUROBI_OPTS, check_solution
 
@@ -175,6 +176,22 @@ def test_large():
 
     assert check_solution(result_dede, result_solution, objective)
     print("=== Passed LARGE value test ===")
+
+
+def test_nested_log():
+    N, M = 2, 2
+    x = dd.Variable((N, M), nonneg=True)
+    resource_constraints = [x[i, :].sum() >= (i + 1) * M for i in range(N)]
+    demand_constraints = [x[:, j].sum() <= (j + 1) * N for j in range(M)]
+    objective = dd.Maximize(sum([dd.log(dd.sum(x[i, :])) for i in range(N)]))
+
+    prob = dd.Problem(objective, resource_constraints, demand_constraints)
+    result_dede = prob.solve(num_cpus=2, solver=dd.ECOS)
+
+    cvxpy_prob = cp.Problem(objective, resource_constraints + demand_constraints, solver=dd.ECOs)
+    result_cvxpy = cvxpy_prob.solve()
+
+    assert check_solution(result_dede, result_cvxpy, objective)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
```
N, M = n, n
x = cp.Variable((N, M), nonneg=True)
resource_constraints = [x[i, :].sum() >= (i + 1) * M for i in range(N)]
demand_constraints = [x[:, j].sum() <= (j + 1) * N for j in range(M)]
objective = cp.Maximize(sum([cp.log(cp.sum(x[i, :])) for i in range(N)]))
constraints = resource_constraints + demand_constraints
```
    
The above problem in dede gave around 1.5 when the answer is ~2.079 ish (ln2 + ln4) with [[0.5, 1.5], [1.5, 2.5]]. This seems to be because the inner sum that is the argument for dd.log expanded each individual term of the sum, making log(x + y) become log(x) + log(y). This means that dede was solving a different problem altogether. 

This PR fixes this for log and quad_over_lin and writes a test to verify correctness.