### PR TITLE
Non-canonicalization method for grouping objectives

### DIFF
--- a/dede/problem.py
+++ b/dede/problem.py
@@ -58,9 +58,7 @@ def time_all_methods(cls):
 
 
 @contextlib.contextmanager
-def _get_distributed_pg(
-    max_cpus_per_node: int, timeout: float = 10.0
-) -> t.Iterator[PlacementGroup]:
+def _get_pg(num_cpus: int, timeout: float = 10.0) -> t.Iterator[PlacementGroup]:
     """Returns a placement group that tries to spread
     workers across all available nodes in the ray network.
 
@@ -74,10 +72,8 @@ def _get_distributed_pg(
     Returns:
         t.Iterator[PlacementGroup]: the placement group
     """
-    nodes = [node for node in ray.nodes() if node["Alive"]]
-
-    bundles = [{"CPU": 1.0}] * min(max_cpus_per_node * len(nodes), _get_ray_cpus())
-    pg = ray.util.placement_group(bundles, strategy="SPREAD")
+    bundles = [{"CPU": 1.0}] * num_cpus
+    pg = ray.util.placement_group(bundles)
     ray.get(pg.ready(), timeout=timeout)
     try:
         yield pg
@@ -338,7 +334,7 @@ class Problem(CpProblem):
         subproblems_invalidated = self._subprob_cache.update_cache(rho, num_cpus, ray_address)
         if subproblems_invalidated:
             # store subproblem in last solution
-            obj_expr_r, obj_expr_d = self._get_grouped_objectives()
+            obj_expr_r, obj_expr_d = self._get_grouped_objectives(self._subprob_cache.num_cpus)
             # reserve the actors needed to create the subproblems
             self._subprob_cache.reserve_placement_group()
             probs = self.get_subproblems(obj_expr_r, obj_expr_d, self._subprob_cache.num_cpus, rho)
@@ -696,7 +692,9 @@ class Problem(CpProblem):
         ]
         return param_idx_r, param_idx_d
 
-    def _get_grouped_objectives(self) -> tuple[list[cp.Expression], list[cp.Expression]]:
+    def _get_grouped_objectives(
+        self, num_cpus: int
+    ) -> tuple[list[cp.Expression], list[cp.Expression]]:
         """Split objective into corresponding constraint groups"""
 
         # See if the grouped objectives are already computed and cached.
@@ -706,7 +704,7 @@ class Problem(CpProblem):
 
         # use a placement group with strategy = SPREAD due to the diminishing returns
         # observed with larger numbers of CPUs
-        with _get_distributed_pg(4) as pg:
+        with _get_pg(num_cpus) as pg:
             var_id_pos_to_idx: dict[VarInfoT, list[tuple[int, int]]] = defaultdict(list)
             for i, constrs_gps, constr_dict in zip(
                 [0, 1],

--- a/dede/problem.py
+++ b/dede/problem.py
@@ -737,7 +737,6 @@ class Problem(CpProblem):
                 ).remote(
                     c,
                     expr_ref,
-                    self._solver,
                     dict_ref,
                     len(self.constrs_gps_r),
                     len(self.constrs_gps_d),
@@ -773,7 +772,6 @@ class Problem(CpProblem):
 def _process_obj_chunk_indices(
     indices: NDArray[np.int64],
     expr_list_ref: list[cp.Expression],
-    solver: str,
     var_id_pos_to_idx: dict[VarInfoT, list[tuple[int, int]]],
     num_r: int,
     num_d: int,
@@ -789,7 +787,7 @@ def _process_obj_chunk_indices(
         # Access the object from the shared reference
         obj = expr_list_ref[idx]
 
-        var_id_pos_list = get_var_id_pos_list_from_cone(obj, solver)
+        var_id_pos_list = get_var_id_pos_list_from_cone(obj)
 
         if not var_id_pos_list:
             if num_r > 0:

--- a/dede/problem.py
+++ b/dede/problem.py
@@ -22,6 +22,7 @@ from .utils import (
     UnionFind,
     VarInfoT,
     expand_expr,
+    get_var_id_pos_list_from_cone,
     get_var_id_pos_list_from_linear,
     get_var_id_pos_list_from_tree,
 )
@@ -58,7 +59,9 @@ def time_all_methods(cls):
 
 
 @contextlib.contextmanager
-def _get_pg(num_cpus: int, timeout: float = 10.0) -> t.Iterator[PlacementGroup]:
+def _get_pg(
+    num_cpus: int, timeout: float = 10.0, strategy: str = "PACK"
+) -> t.Iterator[PlacementGroup]:
     """Returns a placement group that tries to spread
     workers across all available nodes in the ray network.
 
@@ -66,14 +69,14 @@ def _get_pg(num_cpus: int, timeout: float = 10.0) -> t.Iterator[PlacementGroup]:
     the placement group once execution has finished.
 
     Args:
-        max_cpus_per_node (int): how many CPUs to request per node. This is an upper bound on the
-        number of CPUs reserved.
+        max_cpus_per_node (int): how many CPUs to request.
+        strategy: the strategy to use when creating the placement group. Can be "SPREAD" or "PACK".
 
     Returns:
         t.Iterator[PlacementGroup]: the placement group
     """
     bundles = [{"CPU": 1.0}] * num_cpus
-    pg = ray.util.placement_group(bundles)
+    pg = ray.util.placement_group(bundles, strategy=strategy)
     ray.get(pg.ready(), timeout=timeout)
     try:
         yield pg
@@ -702,48 +705,63 @@ class Problem(CpProblem):
         if self._obj_expr_r is not None and self._obj_expr_d is not None:
             return self._obj_expr_r, self._obj_expr_d
 
-        # use a placement group with strategy = SPREAD due to the diminishing returns
-        # observed with larger numbers of CPUs
-        with _get_pg(num_cpus) as pg:
-            var_id_pos_to_idx: dict[VarInfoT, list[tuple[int, int]]] = defaultdict(list)
-            for i, constrs_gps, constr_dict in zip(
-                [0, 1],
-                [self.constrs_gps_r, self.constrs_gps_d],
-                [self.constr_dict_r, self.constr_dict_d],
-            ):
-                for j, constrs in enumerate(constrs_gps):
-                    for constr in constrs:
-                        for var_id_pos in constr_dict[constr.id]:
-                            var_id_pos_to_idx[var_id_pos].append((i, j))
+        var_id_pos_to_idx: dict[VarInfoT, list[tuple[int, int]]] = defaultdict(list)
+        for i, constrs_gps, constr_dict in zip(
+            [0, 1],
+            [self.constrs_gps_r, self.constrs_gps_d],
+            [self.constr_dict_r, self.constr_dict_d],
+        ):
+            for j, constrs in enumerate(constrs_gps):
+                for constr in constrs:
+                    for var_id_pos in constr_dict[constr.id]:
+                        var_id_pos_to_idx[var_id_pos].append((i, j))
 
-            expr_list = expand_expr(self.objective.expr)
+        expr_list = expand_expr(self.objective.expr)
 
-            # put heavy objects in shared memory to avoid serialization overhead
-            expr_ref = ray.put(expr_list)
-            dict_ref = ray.put(dict(var_id_pos_to_idx))
-
-            # chunk the indices to split the work
-            chunks = np.array_split(np.arange(len(expr_list), dtype=np.int64), len(pg.bundle_specs))
-
-            # send the chunks to the remote function for processing
-            futures = [
-                _process_obj_chunk_indices.options(
-                    scheduling_strategy=PlacementGroupSchedulingStrategy(
-                        placement_group=pg,
-                        placement_group_bundle_index=i,
-                    )
-                ).remote(
-                    c,
-                    expr_ref,
-                    dict_ref,
-                    len(self.constrs_gps_r),
-                    len(self.constrs_gps_d),
+        try:
+            # wrap in a 1-element list so downstream `for res in results` matches
+            # the multi-chunk shape returned by the cone/Ray path
+            # do this since it is much faster tha nthe cone version
+            results = [
+                _process_obj_chunk_tree(
+                    expr_list, var_id_pos_to_idx, len(self.constrs_gps_r), len(self.constrs_gps_d)
                 )
-                for i, c in enumerate(chunks)
             ]
+        except Exception as e:
+            print(f"Error in tree-based grouping: {e}. Falling back to cone-based grouping.")
 
-            # block on results
-            results = ray.get(futures)
+            # use a placement group with strategy = SPREAD due to the diminishing returns
+            # observed with larger numbers of CPUs
+            with _get_pg(num_cpus, strategy="SPREAD") as pg:
+                # put heavy objects in shared memory to avoid serialization overhead
+                expr_ref = ray.put(expr_list)
+                dict_ref = ray.put(dict(var_id_pos_to_idx))
+
+                # chunk the indices to split the work
+                chunks = np.array_split(
+                    np.arange(len(expr_list), dtype=np.int64), len(pg.bundle_specs)
+                )
+
+                # send the chunks to the remote function for processing
+                futures = [
+                    _process_obj_chunk_indices_tree.options(
+                        scheduling_strategy=PlacementGroupSchedulingStrategy(
+                            placement_group=pg,
+                            placement_group_bundle_index=i,
+                        )
+                    ).remote(
+                        c,
+                        expr_ref,
+                        self._solver,
+                        dict_ref,
+                        len(self.constrs_gps_r),
+                        len(self.constrs_gps_d),
+                    )
+                    for i, c in enumerate(chunks)
+                ]
+
+                # block on results
+                results = ray.get(futures)
 
         # reconstruct groups
         obj_r: list[cp.Expression] = []
@@ -767,15 +785,17 @@ class Problem(CpProblem):
 
 
 @ray.remote
-def _process_obj_chunk_indices(
+def _process_obj_chunk_indices_tree(
     indices: NDArray[np.int64],
     expr_list_ref: list[cp.Expression],
+    solver: str,
     var_id_pos_to_idx: dict[VarInfoT, list[tuple[int, int]]],
     num_r: int,
     num_d: int,
 ) -> tuple[list[list[int]], list[list[int]]]:
     """
-    Returns only integer indices of the expressions.
+    Returns only integer indices of the expressions. This uses the cone strategy
+    to extract var id positions and is ray-parallelized.
     """
     # Local accumulation of INDICES
     local_r_idx: list[list[int]] = [[] for _ in range(num_r)]
@@ -785,7 +805,7 @@ def _process_obj_chunk_indices(
         # Access the object from the shared reference
         obj = expr_list_ref[idx]
 
-        var_id_pos_list = get_var_id_pos_list_from_tree(obj)
+        var_id_pos_list = get_var_id_pos_list_from_cone(obj, solver)
 
         if not var_id_pos_list:
             if num_r > 0:
@@ -797,6 +817,46 @@ def _process_obj_chunk_indices(
         id_set = set(var_id_pos_to_idx[var_id_pos_list[0]])
         for var_id_pos in var_id_pos_list[1:]:
             id_set &= set(var_id_pos_to_idx[var_id_pos])
+
+        if not id_set:
+            raise ValueError(f"Objective term at index {idx} is not separable.")
+
+        target: tuple[int, int] = list(id_set)[0]
+        if target[0] == 0:
+            local_r_idx[target[1]].append(idx)
+        else:
+            local_d_idx[target[1]].append(idx)
+
+    return local_r_idx, local_d_idx
+
+
+def _process_obj_chunk_tree(
+    expr_list: list[cp.Expression],
+    var_id_pos_to_idx: dict[VarInfoT, list[tuple[int, int]]],
+    num_r: int,
+    num_d: int,
+) -> tuple[list[list[int]], list[list[int]]]:
+    """Returns only integer indices of the expressions. This uses the tree traversal
+    strategy to extract var id positions and is single-threaded.
+
+    In the vast majority of cases, this should be sufficient.
+    """
+    local_r_idx: list[list[int]] = [[] for _ in range(num_r)]
+    local_d_idx: list[list[int]] = [[] for _ in range(num_d)]
+
+    for idx, obj in enumerate(expr_list):
+        var_id_pos_list = get_var_id_pos_list_from_tree(obj)
+
+        if not var_id_pos_list:
+            if num_r > 0:
+                local_r_idx[0].append(idx)
+            elif num_d > 0:
+                local_d_idx[0].append(idx)
+            continue
+
+        id_set = set(var_id_pos_to_idx.get(var_id_pos_list[0], []))
+        for var_id_pos in var_id_pos_list[1:]:
+            id_set &= set(var_id_pos_to_idx.get(var_id_pos, []))
 
         if not id_set:
             raise ValueError(f"Objective term at index {idx} is not separable.")

--- a/dede/problem.py
+++ b/dede/problem.py
@@ -22,8 +22,8 @@ from .utils import (
     UnionFind,
     VarInfoT,
     expand_expr,
-    get_var_id_pos_list_from_cone,
     get_var_id_pos_list_from_linear,
+    get_var_id_pos_list_from_tree,
 )
 
 ObjectiveT = t.Union[cp.Maximize, cp.Minimize]
@@ -787,7 +787,7 @@ def _process_obj_chunk_indices(
         # Access the object from the shared reference
         obj = expr_list_ref[idx]
 
-        var_id_pos_list = get_var_id_pos_list_from_cone(obj)
+        var_id_pos_list = get_var_id_pos_list_from_tree(obj)
 
         if not var_id_pos_list:
             if num_r > 0:

--- a/dede/problem.py
+++ b/dede/problem.py
@@ -129,7 +129,7 @@ class RaySubprobCache:
         if not (
             rho != self._rho
             or ray_address != self._address
-            or (ray_address == "local" and user_num_cpus != self._user_num_cpus)
+            or (user_num_cpus != self._user_num_cpus)
             or not ray.is_initialized()
         ):
             return False

--- a/dede/utils.py
+++ b/dede/utils.py
@@ -261,6 +261,44 @@ def get_var_id_pos_list_from_cone(expr: cp.Expression, solver: str) -> list[VarI
     return var_id_pos_list
 
 
+def get_var_id_pos_list_from_tree(expr: cp.Expression) -> list[VarInfoT]:
+    """Return (var_id, pos) pairs for every variable occurrence in the expression tree.
+
+    Handles any expression (affine or non-affine) by generic recursion into `args`,
+    stopping at Variable or index(Variable, ...) leaves. No canonicalization required.
+    """
+    result: set[VarInfoT] = set()
+
+    def walk(e: t.Any) -> None:
+        if isinstance(e, Variable):
+            if e.shape == ():
+                result.add(VarInfoT(e.id, 0))
+            else:
+                for idx in np.ndindex(e.shape):
+                    pos = int(np.ravel_multi_index(idx[::-1], e.shape[::-1]))
+                    result.add(VarInfoT(e.id, pos))
+            return
+
+        if isinstance(e, index) and isinstance(e.args[0], Variable):
+            var = e.args[0]
+            for idx in get_indices_from_index(e):
+                pos = int(np.ravel_multi_index(idx[::-1], var.shape[::-1]))
+                result.add(VarInfoT(var.id, pos))
+            return
+
+        if isinstance(e, (Constant, Parameter)):
+            return
+
+        if not hasattr(e, "args"):
+            return
+
+        for arg in e.args:
+            walk(arg)
+
+    walk(expr)
+    return sorted(result)
+
+
 class UnionFind:
     def __init__(self, n: int) -> None:
         # roots are defined by self.parents[i] == i


### PR DESCRIPTION
- I think canonicalization is too powerful a tool just to find variables inside an expression, grouping objectives  could probably be done just by a tree walk like with the _line version, this speeds things up considerably 
- Moved to tree traversal method to get variable positions and ids (written by claude)
- Fixed bug where cache would not be invalidated if the user changed the number of CPUs with a non-local address (this was a leftover from a pre-placement group version)